### PR TITLE
quickstart docs + docker setup fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.11-slim
 
-WORKDIR /app
-
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
+
+WORKDIR /src
 
 CMD ["python", "main.py"]

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,48 @@
+### Quickstart
+
+#### Dockerized App + Dockerized Postgres (no Compose)
+Run two containers, one for the FastAPI app and one for the Postgres database. We will use a network to allow the containers to communicate with each other.
+
+1. Pull the image from Docker Hub
+    ```bash
+    docker pull postgres
+    ```
+1. Create a docker network
+This will allow the containers to communicate with each other.
+    ```bash
+    docker network create demo-network
+    ```
+1. Start the Postgres container
+You can run the `./scripts/run_pg.bat` script which is
+    ```bash
+    docker run --name demo_pg \ # important to keep this static since it's passed in run command to fastapi app
+    --network demo-network \  # this is the network we created in step above
+    -e POSTGRES_PASSWORD=demopassword \
+    -e POSTGRES_DB=demo_db  \ 
+    -p '5432:5432' \ # note double quotes for bat, single for bash
+    -d postgres
+    ```
+1. Verify postgres is running and can create connection
+    ```bash
+    psql -h localhost -p 5432 -U postgres -d demo_db
+    ```
+    password: `demopassword`
+1. Build the FastAPI image
+    ```bash
+    docker build -t pavel-gh-2 .
+    ```
+    Currently `scripts/` is copied in the image (i think) but is not nec.
+1. Start the FastAPI container
+    ```bash
+    docker run -d \
+    -p 8000:8000 \
+    --network demo-network \
+    -e DB_HOST=demo_pg \ # this comes from --name arg in run command for postgres container
+    -e DB_PASSWORD=demopassword \
+    -e HOST=0.0.0.0 \ # defaults to 127.0.0.1 which is not accessible from outside the container
+    pavel-gh-2
+    ```
+    You should be able to goto `http://localhost:8000/` and get redirected to /docs.
+### Notes
+- `uvloop` is linux only.
+    - could replace with `asyncio` for cross-platform support.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pydantic==2.7.1
 pydantic_core==2.18.2
 Pygments==2.18.0
 python-dotenv==1.0.1
+python-jose==3.3.0
 python-multipart==0.0.9
 PyYAML==6.0.1
 rich==13.7.1

--- a/scripts/run_pg.bat
+++ b/scripts/run_pg.bat
@@ -1,0 +1,1 @@
+docker run --name demo_pg --network demo-network -e POSTGRES_PASSWORD=demopassword -e POSTGRES_DB=demo_db -p "5432:5432" -d postgres


### PR DESCRIPTION
- added `python-jose` to requirements since this is referenced in `src/api/services/jwt.py`. This is correct, yes?
- fixed fastapi app Dockerfile to use `/src` as WORKDIR. Might not need to COPY everything, only src.
- added a bat script for run_pg. A copy of the bash script but has an extra arg to use a docker networ (inter-container comm).
- added a readme with my setup findings.